### PR TITLE
Fix for Auto indenting often being wrong #250

### DIFF
--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -189,7 +189,7 @@
 
     const spaces = /^\s*/.exec(state.doc.lineAt(line).text)?.[0].length
     const tabs = /^\t*/.exec(state.doc.lineAt(line).text)?.[0].length
-    return Math.floor(spaces / 4) + tabs
+    return Math.floor((spaces - tabs) / 4) + tabs
   }
 
   const updateItem = debounce(() => {


### PR DESCRIPTION
the regex for const spaces matches both spaces and tabs.  There might be a better regex to grab only spaces without catching the tabs, but an easy fix is to just subtract the number of tabs instead.